### PR TITLE
Bug fix for dssystem port

### DIFF
--- a/sysutils/dssystem/Makefile
+++ b/sysutils/dssystem/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	dssystem
 PORTVERSION=	14.1
-PORTREVISION=	7
+PORTREVISION=	8
 CATEGORIES=	sysutils
 MASTER_SITES=	https://cdn1.tn.ixsystems.com/asigra/14.1/hotfixes/ \
 		https://asigra-f611.kxcdn.com/14.1/hotfixes/

--- a/sysutils/dssystem/files/dssystem.in
+++ b/sysutils/dssystem/files/dssystem.in
@@ -44,6 +44,7 @@ command=/usr/local/ds-system/dssystem_dc
 dssystem_flags="--daemon --lang en"
 sig_stop="TERM"
 load_rc_config $name
+start_precmd=dssystem_prestart
 stop_cmd=dssystem_stop
 run_rc_command "$1"
 


### PR DESCRIPTION
This commit fixes a bug in dssystem port where we did not run prestart function which correctly determined and updated ip of DSOP.jnlp file.